### PR TITLE
Change analytics adapters' event count tests to reflect new error events their malformed tests are creating. 

### DIFF
--- a/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
+++ b/test/spec/modules/prebidmanagerAnalyticsAdapter_spec.js
@@ -98,7 +98,7 @@ describe('Prebid Manager Analytics Adapter', function () {
       events.emit(constants.EVENTS.AUCTION_END, {});
       events.emit(constants.EVENTS.BID_TIMEOUT, {});
 
-      sinon.assert.callCount(prebidmanagerAnalytics.track, 6);
+      sinon.assert.callCount(prebidmanagerAnalytics.track, 7);
     });
   });
 

--- a/test/spec/modules/sigmoidAnalyticsAdapter_spec.js
+++ b/test/spec/modules/sigmoidAnalyticsAdapter_spec.js
@@ -38,7 +38,7 @@ describe('sigmoid Prebid Analytic', function () {
       events.emit(constants.EVENTS.BID_RESPONSE, {});
       events.emit(constants.EVENTS.BID_WON, {});
 
-      sinon.assert.callCount(sigmoidAnalytic.track, 5);
+      sinon.assert.callCount(sigmoidAnalytic.track, 7);
     });
   });
   describe('build utm tag data', function () {


### PR DESCRIPTION
Sigmoid and prebidanalyticsmanager test files are creating errors, which are now events, so the event counts go up. 